### PR TITLE
temporary magento connect 2.0

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -58,6 +58,7 @@
       { "type": "vcs", "url": "git://github.com/netz98/N98_ManageRules.git" },
       { "type": "vcs", "url": "git://github.com/netz98/N98_CheckoutFilters.git" },
       { "type": "vcs", "url": "git://github.com/laurent35240/magento-sass.git" }
+      { "type": "composer", "url": "http://connect20.thebod.de/" }
    ],
    "require-all": true
 }


### PR DESCRIPTION
connect20.thebod.de holds the packages.json right now, until the last bugs are fixed and it can be run on a server via cronjob and automatically ;-)
