### PR TITLE
Update Ecomdev_PHPUnit

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -43,7 +43,7 @@
       { "type": "vcs", "url": "git://github.com/openstream/ogtags.git" },
       { "type": "vcs", "url": "git://github.com/openstream/SaferpayEcommerce.git" },
       { "type": "vcs", "url": "git://github.com/openstream/SaferpayBusiness.git" },
-      { "type": "vcs", "url": "git://github.com/IvanChepurnyi/EcomDev_PHPUnit.git" },
+      { "type": "vcs", "url": "git://github.com/EcomDev/EcomDev_PHPUnit.git" },
       { "type": "vcs", "url": "git://github.com/sprankhub/Spranks_ConfigurableTierPrices.git" },
       { "type": "vcs", "url": "git://github.com/sprankhub/Spranks_RefreshBlockHtmlCache.git" },
       { "type": "vcs", "url": "git://github.com/sprankhub/Spranks_StorePickup.git" },


### PR DESCRIPTION
Change IvanChepurnyi/EcomDev_PHPUnit to EcomDev/EcomDev_PHPUnit.git because the repository is migrated to EcomDev, https://twitter.com/IvanChepurnyi/status/319349955473059842
