### PR TITLE
Add payone extension

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -75,6 +75,7 @@
       { "type": "vcs", "url": "git://github.com/sitewards/B2BProfessional.git" },
       { "type": "vcs", "url": "git://github.com/sitewards/Giveaway.git" },
       { "type": "vcs", "url": "git://github.com/sitewards/BigPipe.git" },
+      { "type": "vcs", "url": "git://github.com/PAYONE/magento.git" },
       { "type": "vcs", "url": "git://github.com/mzeis/Emzee_Dev.git" },
       { "type": "vcs", "url": "git://github.com/diglin/Diglin_Github.git" },
       { "type": "vcs", "url": "git://github.com/diglin/Diglin_Chat.git" },


### PR DESCRIPTION
Magento Payone extension is available at Github, so let's make it available!
