### PR TITLE
Add magento-amd and foundation4-amd

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -73,6 +73,8 @@
       { "type": "vcs", "url": "git://github.com/netz98/N98_InfoFiles.git" },
       { "type": "vcs", "url": "git://github.com/netz98/N98_ManageRules.git" },
       { "type": "vcs", "url": "git://github.com/netz98/N98_CheckoutFilters.git" },
+      { "type": "vcs", "url": "git://github.com/maxbucknell/magento-amdjs.git" },
+      { "type": "vcs", "url": "git://github.com/maxbucknell/foundation4-amd.git" },
       { "type": "vcs", "url": "git://github.com/laurent35240/magento-sass.git" },
       { "type": "vcs", "url": "git://github.com/sitewards/B2BProfessional.git" },
       { "type": "vcs", "url": "git://github.com/sitewards/BigPipe.git" },


### PR DESCRIPTION
I have created a module to parse JavaScript modules defined according to [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD). It compiles them into one file, then caches that. It allows for more modular front end development, which is nice.

I also created a version of the Zurb Foundation v4 JavaScript files, slightly modified so that they export themselves as AMD modules. I request that both of these be added to the repository.

Best wishes,
Max.
