### PR TITLE
Add CmsUploaderImages module

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -248,6 +248,7 @@
       { "type": "vcs", "url": "git://github.com/dabio/magento-singleshipping.git"},
       { "type": "vcs", "url": "git://github.com/dweeves/magmi-git.git"},
       { "type": "vcs", "url": "git://github.com/timste/Timste_Emailqueue.git"},
+      { "type": "vcs", "url": "git://github.com/DanielSousa/CmsUploadImages.git"},
       { "type": "composer", "url": "http://packages.fooman.co.nz/" },
       { "type": "composer", "url": "http://packages.firegento.com/connect20/" },
 		{


### PR DESCRIPTION
Magento 1.9.1 has a bug when the user try to upload an image on cms, "nothing happens" and it's not possible to upload any image.