### PR TITLE
List LogMail Extension

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -3,6 +3,7 @@
    "homepage": "http://packages.firegento.com",
    "description": "Please visit https://github.com/magento-hackathon/composer-repository for further informaton.",
    "repositories": [
+      { "type": "vcs", "url": "git://github.com/kojiromike/LogMail" },
       { "type": "vcs", "url": "git://github.com/bragento/magento-core" },
       { "type": "vcs", "url": "git://github.com/astorm/MagentoBetter404" },
       { "type": "vcs", "url": "git://github.com/adyenpayments/magento.git" },


### PR DESCRIPTION
The LogMail Extension helps you debug emails – instead of going to an smtp server, it causes Magento to write mails directly to files in var/log,