### PR TITLE
Add Envalo_Widget module.

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -142,6 +142,7 @@
       { "type": "vcs", "url": "git://github.com/Zookal/Magento-FixFormKey.git" },
       { "type": "vcs", "url": "git://github.com/Zookal/Magento-MyTableOptimization.git" },
       { "type": "vcs", "url": "git://github.com/tim-reynolds/magento-qconfig.git" },
+      { "type": "vcs", "url": "git://github.com/Envalo/Widget.git" },
       { "type": "vcs", "url": "git://github.com/magento-hackathon/Magento-PSR-0-Autoloader.git" },
       { "type": "vcs", "url": "git://github.com/phpro/mage-remote-media.git"},
       { "type": "vcs", "url": "git://github.com/ajbonner/mage-resque.git" },


### PR DESCRIPTION
This module fixes a bug in Magento widgets, as well adds the ability to target specific CMS pages with your widgets through the layout editor.