### PR TITLE
Add original version of Magneto-Debug

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -95,6 +95,7 @@
       { "type": "vcs", "url": "git://github.com/avstudnitz/AvS_ScopeHint.git" },
       { "type": "vcs", "url": "git://github.com/avstudnitz/AvS_AdminNotificationAdvanced.git" },
       { "type": "vcs", "url": "git://github.com/thebod/Thebod_Shippingrates.git" },
+      { "type": "vcs", "url": "git://github.com/madalinoprea/magneto-debug.git" },
       { "type": "vcs", "url": "git://github.com/moleman/magneto-debug.git" },
       { "type": "vcs", "url": "git://github.com/liip/magento-xhprof.git" },
       { "type": "vcs", "url": "git://github.com/magento-hackathon/mage-git-info.git" },


### PR DESCRIPTION
Either this pull request or [this](https://github.com/magento-hackathon/composer-repository/pull/288) one should be accepted. 

This request only adds the original author's version of Magneto-Debug and leaves the current fork in place. The other pull request removes the outdated, forked version and replaces it with the original author's updated version. 

The fork is outdated and does not install correctly with Magento Composer Installer since it is requiring dev-master.

Ideally the fork would be removed from satis.json since the original should always be preferred.