### PR TITLE
Replace Magneto-Debug with Original

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -96,7 +96,6 @@
       { "type": "vcs", "url": "git://github.com/avstudnitz/AvS_AdminNotificationAdvanced.git" },
       { "type": "vcs", "url": "git://github.com/thebod/Thebod_Shippingrates.git" },
       { "type": "vcs", "url": "git://github.com/madalinoprea/magneto-debug.git" },
-      { "type": "vcs", "url": "git://github.com/moleman/magneto-debug.git" },
       { "type": "vcs", "url": "git://github.com/liip/magento-xhprof.git" },
       { "type": "vcs", "url": "git://github.com/magento-hackathon/mage-git-info.git" },
       { "type": "vcs", "url": "git://github.com/netz98/N98_Base.git" },

--- a/satis.json
+++ b/satis.json
@@ -95,6 +95,7 @@
       { "type": "vcs", "url": "git://github.com/avstudnitz/AvS_ScopeHint.git" },
       { "type": "vcs", "url": "git://github.com/avstudnitz/AvS_AdminNotificationAdvanced.git" },
       { "type": "vcs", "url": "git://github.com/thebod/Thebod_Shippingrates.git" },
+      { "type": "vcs", "url": "git://github.com/madalinoprea/magneto-debug.git" },
       { "type": "vcs", "url": "git://github.com/moleman/magneto-debug.git" },
       { "type": "vcs", "url": "git://github.com/liip/magento-xhprof.git" },
       { "type": "vcs", "url": "git://github.com/magento-hackathon/mage-git-info.git" },


### PR DESCRIPTION
Either this pull request or [this](https://github.com/magento-hackathon/composer-repository/pull/287) one should be accepted. 

This request removes an outdated, forked version of Magneto-Debug and replaces it with the original author's updated version. The other pull request only adds the original author's version and leaves the current fork in place.

The fork is outdated and does not install correctly with Magento Composer Installer since it is requiring dev-master.

Ideally the fork would be removed from satis.json since the original should always be preferred.