### PR TITLE
Update repo name of Adyen Magento

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -21,7 +21,7 @@
       { "type": "vcs", "url": "git://github.com/staempfli/magento-product-attachment.git"},
       { "type": "vcs", "url": "git://github.com/astorm/MagentoBetter404" },
       { "type": "vcs", "url": "git://github.com/vmbl/ajaxcart.git" },
-      { "type": "vcs", "url": "git://github.com/Adyen/magento.git" },
+      { "type": "vcs", "url": "git://github.com/Adyen/adyen-magento.git" },
       { "type": "vcs", "url": "git://github.com/comwrap/magento-comwrap-pdf.git" },
       { "type": "vcs", "url": "git://github.com/ProxiBlue/OrderSyncQueRunner" },
       { "type": "vcs", "url": "git://github.com/ProxiBlue/NewRelic" },


### PR DESCRIPTION
The Adyen repo has been renamed from magento to adyen-magento.