### PR TITLE
Added MageHost_RewriteFix

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -468,6 +468,7 @@
       { "type": "vcs", "url": "git://github.com/mailchimp/mc-magento.git" },
       { "type": "vcs", "url": "git://github.com/bartnowaczyk/log.git" },
       { "type": "vcs", "url": "git://github.com/matiashidalgo/static-version.git" },
+      { "type": "vcs", "url": "git://github.com/magehost/magehost_rewritefix.git" },
       { "type": "composer", "url": "https://packages.fooman.co.nz/" },
       { "type": "composer", "url": "https://repo.magento.com/" },
       { "type": "composer", "url": "https://packages.firegento.com/connect20/" },


### PR DESCRIPTION
Due to bugs in Magento, once an rewrite URL ends with -[number] you get more and more rewrite URLs to the same target. The number gets higher and higher. Indexing gets slower and slower.

This extension is a workaround for this problem. Requires Magento 1.7.0.2 or greater.